### PR TITLE
Howards proposed minor fixes - three tiny updates to the test file #staff

### DIFF
--- a/test/index-test.js
+++ b/test/index-test.js
@@ -29,7 +29,7 @@ describe('BandInput component', () => {
     const wrapper = shallow(<BandInput />)
     expect(wrapper.state('name'), "BandInput should mount with this.state.text equal to ''").to.equal('')
     let input = wrapper.find('input').first()
-    input.simulate('change', { target: { value: 'Hello' } })
+    input.simulate('change', { target: { name: 'name', value: 'Hello' } })
     expect(wrapper.state('name'), "BandInput state did not contain the correct value").to.equal('Hello')
   })
 
@@ -68,7 +68,7 @@ describe('Redux', () => {
     expect(store.getState().bands, "'bands' not found in the store").to.exist
     expect(store.getState().bands, "Initial state of 'bands' should be an empty array").to.be.empty
 
-    input.simulate('change', { target: { value: 'Hello' } })
+    input.simulate('change', { target: { name: 'name', value: 'Hello' } })
     form.simulate('submit',  { preventDefault() {} })
 
     expect(store.getState().bands[0].name).to.equal("Hello")

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -19,7 +19,7 @@ describe('BandInput component', () => {
     expect(wrapper.find('input').first().type()).to.equal('input');
   });
 
-  it('has an initial state with text key set to empty string', () => {
+  it('has an initial state with name key set to empty string', () => {
     const wrapper = shallow(<BandInput />)
     expect(wrapper.state(), "BandInput state was not found").to.exist
     expect(wrapper.state('name')).to.equal('')


### PR DESCRIPTION
If a student chooses to dynamically update the name, the tests need the target to have a name property.  Although minor, it's a particularly frustrating issue since students are taught to update using this syntax
`[event.target.name]: event.target.value`
and of course it works fine in the browser this way.
The other update is the old version of this lab used "text" as the key where now it's "name" and there is one instance of "text" that didn't get changed over.  *Bonus* is this closes https://github.com/learn-co-curriculum/building-forms-lab/issues/16
#staff